### PR TITLE
컴포넌트 커스터마이징 및 글로벌 스타일 추가

### DIFF
--- a/src/components/customs/Box.tsx
+++ b/src/components/customs/Box.tsx
@@ -1,0 +1,36 @@
+import { Box } from '@mui/material';
+import { purple } from '@mui/material/colors'
+
+const BACKGROUNDCOLOR = purple[200];
+
+export function CenterBox({ children }) {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+      }}
+      marginTop={16} // todo: fix this
+    >
+      {children}
+    </Box>
+  )
+}
+
+export function PageBox({ children }) {
+  return (
+    <Box sx={{
+      margin: '0 auto',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      textAlign: 'center',
+      maxWidth: '414px', // ios se 에 맞춘 maxWidth
+      minHeight: '100vh', // todo: fix this
+      backgroundColor: BACKGROUNDCOLOR,
+    }}>
+      {children}
+    </Box>
+  )
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,58 +1,28 @@
-import { Box, Typography, Button } from '@mui/material';
+import { Typography, Button } from '@mui/material';
 
-import { purple } from '@mui/material/colors'
-
-const color = purple[200];
+import { CenterBox, PageBox } from '../components/customs/Box';
 
 function Home() {
+  console.log(CenterBox)
+
   return (
-    <Box
-      sx={{
-        margin: '0 auto',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        backgroundColor: color
-      }}
-      minHeight="100vh" // todo: fix this
-      maxWidth="414px"
-    >
-      <Box>
-        <Box
-          sx={{
-            marginTop: 8,
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-          }}
-        >
-          <Typography variant='h2'>
-            만다라트
-          </Typography>
-          <Typography variant='body1'>
-            나만의 목표를 만들어요
-          </Typography>
-        </Box>
-      </Box>
-      <Box
-        sx={{
-          marginTop: 16
-        }}
-      >
+    <PageBox>
+      <CenterBox>
+        <Typography variant='h2'>
+          만다라트
+        </Typography>
+        <Typography variant='body1'>
+          나만의 목표를 만들어요
+        </Typography>
+      </CenterBox>
+      <CenterBox>
         <Typography variant='h2'>왕멋진로고</Typography>
-      </Box>
-      <Box
-        sx={{
-          margin: '0 2',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-        }}
-      >
+      </CenterBox>
+      <CenterBox>
         <Button>Google</Button>
         <Button>Kakao</Button>
-      </Box>
-    </Box >
+      </CenterBox>
+    </PageBox>
   )
 }
 

--- a/src/pages/__tests__/Home.test.tsx
+++ b/src/pages/__tests__/Home.test.tsx
@@ -9,6 +9,12 @@ describe('Home', () => {
     expect(getByText('나만의 목표를 만들어요')).not.toBeNull();
   })
 
+  it('renders Logo.', () => {
+    const { getByText } = render(<Home />);
+
+    expect(getByText('왕멋진로고')).not.toBeNull();
+  })
+
   it('renders Login Buttons', () => {
     const { getByRole } = render(<Home />);
 


### PR DESCRIPTION
* 홈페이지(Home)를 제작하면서 Material UI의 Box Component를 커스터마이징한 것을 `components/customs/*.tsx`으로 분리
* Home 페이지의 로고 테스트도 추가 